### PR TITLE
Update gasPrice for matic mumbai testnet

### DIFF
--- a/api.js
+++ b/api.js
@@ -33,7 +33,7 @@ let simpleTokenAbi = require("@razor-network/contracts/abi/SchellingCoin.json");
 const options = {
   transactionConfirmationBlocks: 1,
   gas: 1000000,
-  gasPrice: gasMultiplier * 70000000000,
+  gasPrice: gasMultiplier * 1000000000,
 };
 // let numBlocks = 10
 let stakeManager = new web3.eth.Contract(


### PR DESCRIPTION
This PR sets the gasPrice for Matic Mumbai testnet to `1Gwei` (Safe low).